### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ $ make app-exercises-load-php
 $ make compose
 ```
 
-Go to [https://ru.code-basics.test](ru.code-basics.test)
-Go to [https://en.code-basics.test](en.code-basics.test)
+Go to [https://ru.code-basics.test](https://ru.code-basics.test)
+Go to [https://en.code-basics.test](https://en.code-basics.test)


### PR DESCRIPTION
Поправил ссылку, раньше она вела на [немного не туда](https://github.com/hexlet-basics/hexlet_basics/blob/master/ru.code-basics.test)