### PR TITLE
fix unusual classes and fix aligment

### DIFF
--- a/services/app/lib/hexlet_basics_web/templates/language/module/lesson/index.html.slime
+++ b/services/app/lib/hexlet_basics_web/templates/language/module/lesson/index.html.slime
@@ -5,7 +5,7 @@ div
       h2 
         = module_description.name
   .show id="module_#{@module.id}"
-    .row.d-flex.flex-row
+    .row
       .col-12.col-md-6.lead.mt-4
         = for lesson <- @lessons do
           - lesson_description = @descriptions_by_lesson[lesson.id]
@@ -22,5 +22,5 @@ div
                     | .&nbsp;
                     = lesson_description.name
 
-      .col-12.col-md-6.mt-3
+      .col-12.col-md-6.mt-4
         p.lead= module_description.description

--- a/services/app/lib/hexlet_basics_web/templates/language/show.html.slime
+++ b/services/app/lib/hexlet_basics_web/templates/language/show.html.slime
@@ -16,12 +16,12 @@ h1.text-center.display-3= @header
 
 = for module <- @modules do
   div
-    .row.mt-5.d-flex.flex-row
+    .row.mt-5
       .col-12
         - module_description = @descriptions_by_module[module.id]
         h2
           = module_description.name
-    .row.d-flex.flex-row
+    .row
       .col-12.col-md-6.mt-4
         ul class="list-group"
           = for lesson <- module.lessons do
@@ -37,6 +37,6 @@ h1.text-center.display-3= @header
                 .ml-auto
                   i class="text-primary fas fa-check"
 
-      .col-12.col-md-6.mt-3
+      .col-12.col-md-6.mt-4
         div
           = module_description.description

--- a/services/app/lib/hexlet_basics_web/templates/layout/app.html.slime
+++ b/services/app/lib/hexlet_basics_web/templates/layout/app.html.slime
@@ -41,7 +41,7 @@ html.h-100 lang=@locale
                 img.ml-3(width="25px" src=Routes.static_path(@conn, "/images/flag-#{switch_map[@locale]}.svg") alt="#{gettext("Switch language to")} #{switch_map[@locale]}")
 
     main.mt-5.flex-fill
-      .container-fluid.container-xl
+      .container-xl
         = for name <- [:info, :error] do
           - message = get_flash(@conn, name)
           = if message do
@@ -53,7 +53,7 @@ html.h-100 lang=@locale
         = render @view_module, @view_template, assigns
 
     footer
-      .container.mt-7.pt-6.pb-3.border-top
+      .container-xl.mt-7.pt-6.pb-3.border-top
         .row
           .col
             div


### PR DESCRIPTION
Фиксики-минификсики
Убрал зачем-то написанные классы у `.row` (оно и так flex и flex-row)
убрал `.container-fluid` - бо с `.container-xl` он уже не работает

отступы привел к `.mt-4` в обоих блоках

Не смог протестировать локально [вот этот файл]( services/app/lib/hexlet_basics_web/templates/language/module/lesson/index.html.slime), потому что не понял где его открыть (возможно он уже и не используется)