### PR TITLE
improve tabs info error\success color

### DIFF
--- a/services/web/assets/js/lesson/components/TabsBox.jsx
+++ b/services/web/assets/js/lesson/components/TabsBox.jsx
@@ -26,9 +26,9 @@ const TabsBox = (props) => {
   const { lesson, language } = useContext(EntityContext);
   const { currentTabInfo, checkInfo } = useSelector((state) => state);
 
-  // TODO: badge-<classes> does not work. It seems tabler has a bug.
-  const badgeClassName = cn('badge mb-2 mb-sm-0 p-2', {
-    'text-success': checkInfo.passed,
+  const badgeClassName = cn('badge badge-outline mb-2 mb-sm-0 p-2', {
+    'bg-green-lt': checkInfo.passed,
+    'bg-red-lt': !checkInfo.passed,
   });
   const headline = checkInfo.result ? t(`check.${checkInfo.result}.headline`) : null;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23584933/78001368-43bf5280-733e-11ea-8448-de6a0274f69c.png)
![image](https://user-images.githubusercontent.com/23584933/78001397-49b53380-733e-11ea-8898-526600911088.png)

> // TODO: badge-<classes> does not work. It seems tabler has a bug.

it's no bug, this is Bootstrap 5
[https://github.com/twbs/bootstrap/pull/28458](https://github.com/twbs/bootstrap/pull/28458)